### PR TITLE
Fix C++ rule; rename rule; add CI action

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,41 +1,6 @@
 common --enable_platform_specific_config
 build --verbose_failures
 
-# Shared configuration flags to build and test Bazel on RBE.
-build:remote_shared --define=EXECUTOR=remote
-build:remote_shared --remote_instance_name=projects/bazel-untrusted/instances/default_instance
-build:remote_shared --remote_executor=grpcs://remotebuildexecution.googleapis.com
-build:remote_shared --remote_timeout=600
-build:remote_shared --google_default_credentials
-build:remote_shared --jobs=100
-build:remote_shared --action_env=PATH=/bin:/usr/bin:/usr/local/bin
-build:remote_shared --disk_cache=
-build:remote_shared --java_runtime_version=rbe_jdk
-build:remote_shared --tool_java_runtime_version=rbe_jdk
-# Workaround for singlejar incompatibility with RBE
-build:remote_shared --noexperimental_check_desugar_deps
-
-# Configuration to build and test Bazel on RBE on Ubuntu 18.04 with Java 11
-build:ubuntu1804_java11 --extra_toolchains=@rbe_ubuntu1804_java11//java:all
-build:ubuntu1804_java11 --crosstool_top=@rbe_ubuntu1804_java11//cc:toolchain
-build:ubuntu1804_java11 --extra_toolchains=@rbe_ubuntu1804_java11//config:cc-toolchain
-build:ubuntu1804_java11 --extra_execution_platforms=//:rbe_ubuntu1804_java11_platform
-build:ubuntu1804_java11 --extra_execution_platforms=//:rbe_ubuntu1804_java11_highcpu_platform
-build:ubuntu1804_java11 --host_platform=//:rbe_ubuntu1804_java11_platform
-build:ubuntu1804_java11 --platforms=//:rbe_ubuntu1804_java11_platform
-build:ubuntu1804_java11 --config=remote_shared
-
-# Alias
-build:remote --config=ubuntu1804_java11
-
-build:macos --macos_minimum_os=10.10
-
-# Enable Bzlmod
-build:bzlmod --experimental_enable_bzlmod
-# TODO(pcloudy): The following should be removed after fixing https://github.com/bazelbuild/bazel/issues/14279
-build:bzlmod --crosstool_top=@rules_cc.0.0.1.cc_configure.local_config_cc//:toolchain
-build:bzlmod --xcode_version_config=@rules_cc.0.0.1.cc_configure.local_config_xcode//:host_xcodes
-
 # User-specific .bazelrc
 try-import user.bazelrc
 

--- a/.bazelrc
+++ b/.bazelrc
@@ -1,1 +1,42 @@
+common --enable_platform_specific_config
+build --verbose_failures
+
+# Shared configuration flags to build and test Bazel on RBE.
+build:remote_shared --define=EXECUTOR=remote
+build:remote_shared --remote_instance_name=projects/bazel-untrusted/instances/default_instance
+build:remote_shared --remote_executor=grpcs://remotebuildexecution.googleapis.com
+build:remote_shared --remote_timeout=600
+build:remote_shared --google_default_credentials
+build:remote_shared --jobs=100
+build:remote_shared --action_env=PATH=/bin:/usr/bin:/usr/local/bin
+build:remote_shared --disk_cache=
+build:remote_shared --java_runtime_version=rbe_jdk
+build:remote_shared --tool_java_runtime_version=rbe_jdk
+# Workaround for singlejar incompatibility with RBE
+build:remote_shared --noexperimental_check_desugar_deps
+
+# Configuration to build and test Bazel on RBE on Ubuntu 18.04 with Java 11
+build:ubuntu1804_java11 --extra_toolchains=@rbe_ubuntu1804_java11//java:all
+build:ubuntu1804_java11 --crosstool_top=@rbe_ubuntu1804_java11//cc:toolchain
+build:ubuntu1804_java11 --extra_toolchains=@rbe_ubuntu1804_java11//config:cc-toolchain
+build:ubuntu1804_java11 --extra_execution_platforms=//:rbe_ubuntu1804_java11_platform
+build:ubuntu1804_java11 --extra_execution_platforms=//:rbe_ubuntu1804_java11_highcpu_platform
+build:ubuntu1804_java11 --host_platform=//:rbe_ubuntu1804_java11_platform
+build:ubuntu1804_java11 --platforms=//:rbe_ubuntu1804_java11_platform
+build:ubuntu1804_java11 --config=remote_shared
+
+# Alias
+build:remote --config=ubuntu1804_java11
+
+build:macos --macos_minimum_os=10.10
+
+# Enable Bzlmod
+build:bzlmod --experimental_enable_bzlmod
+# TODO(pcloudy): The following should be removed after fixing https://github.com/bazelbuild/bazel/issues/14279
+build:bzlmod --crosstool_top=@rules_cc.0.0.1.cc_configure.local_config_cc//:toolchain
+build:bzlmod --xcode_version_config=@rules_cc.0.0.1.cc_configure.local_config_xcode//:host_xcodes
+
+# User-specific .bazelrc
+try-import user.bazelrc
+
 build --workspace_status_command=scripts/workspace_status.sh

--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -1,0 +1,29 @@
+name: CI
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    # virtual environments: https://github.com/actions/virtual-environments
+    runs-on: ubuntu-20.04
+
+    steps:
+      # Caches and restores the bazelisk download directory.
+      - name: Cache bazelisk download
+        uses: actions/cache@v2
+        env:
+          cache-name: bazel-cache
+        with:
+          path: ~/.cache/bazelisk
+          key: ${{ runner.os }}-${{ env.cache-name }}-${{ github.ref }}
+          restore-keys: |
+            ${{ runner.os }}-${{ env.cache-name }}-development
+
+
+      # Checks-out your repository under $GITHUB_WORKSPACE, which is the CWD for
+      # the rest of the steps
+      - uses: actions/checkout@v2
+
+      # build
+      - name: Build the code
+        run: bazel build //...

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![CI](https://github.com/kigster/rules_idea_poc/actions/workflows/bazel.yml/badge.svg)](https://github.com/kigster/rules_idea_poc/actions/workflows/bazel.yml)
+
 # rules_idea_poc
 
 A rudimentary proof-of-concept implementation of IDEA's [Shared Indexes](https://www.jetbrains.com/help/idea/shared-indexes.html) under Bazel, circa September 2020.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![CI](https://github.com/kigster/rules_idea_poc/actions/workflows/bazel.yml/badge.svg)](https://github.com/kigster/rules_idea_poc/actions/workflows/bazel.yml)
+[![CI](https://github.com/flarebuild/rules_idea_poc/actions/workflows/bazel.yml/badge.svg)](https://github.com/flarebuild/rules_idea_poc/actions/workflows/bazel.yml)
 
 # rules_idea_poc
 

--- a/README.md
+++ b/README.md
@@ -54,5 +54,5 @@ directory: 1 file: 6
 
 ### Digging deeper
 
-- The source for the targets invoked above is defined in `//jetbrains/jetbrains_shared_index.bzl`
+- The source for the targets invoked above is defined in `//jetbrains/jetbrains_shared_index_runtime.bzl`
 - All of the output for the tools can be found in `bazel-jetbrains-out/` via the convenience symlink created, including all of the other content created by Jebtrains IDEs, be sure to inspect this output during further development.

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -2,10 +2,10 @@ workspace(name = "rules_idea_poc")
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
-load("//jetbrains:jetbrains_shared_index.bzl", 'jetbrains_shared_index')
+load("//jetbrains:jetbrains_shared_index_runtime.bzl", 'jetbrains_shared_index_runtime')
 
-jetbrains_shared_index(
-    name = "flare_shared_index",
+jetbrains_shared_index_runtime(
+    name = "flare_shared_index_runtime",
     uploader_sha = "",
     upload_url = "https://storage.googleapis.com/flare-public",
 )

--- a/jetbrains/jetbrains_shared_index_runtime.bzl
+++ b/jetbrains/jetbrains_shared_index_runtime.bzl
@@ -123,7 +123,7 @@ def _impl(repository_ctx):
         content = IDE_PROPERTIES_CONTENT,
     )
 
-jetbrains_shared_index = repository_rule(
+jetbrains_shared_index_runtime = repository_rule(
     implementation= _impl,
     local = True,
     attrs = {

--- a/src/main/cpp/BUILD
+++ b/src/main/cpp/BUILD
@@ -1,6 +1,8 @@
 load("@rules_cc//cc:defs.bzl", "cc_binary")
 
+package(default_visibility = ["//visibility:public"])
+
 cc_binary(
     name = "hello-world",
-    srcs = ["hello-world.cc"],
+    srcs = [":hello_world.cc"],
 )

--- a/src/main/java/com/example/BUILD
+++ b/src/main/java/com/example/BUILD
@@ -1,0 +1,1 @@
+package(default_visibility = ["//visibility:public"])


### PR DESCRIPTION
This PR fixes a typo that referenced `hello-world.cc` instead of `hello_world.cd`, and adds Github actions that runs bazel build on the repo. It also renames `jetbrains_shared_index` to `jetbrains_shared_index_runtime`.